### PR TITLE
WSC 6.0 Kompatbilität

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,8 +1,8 @@
 Hersteller:
 
 Niklas Friedrich Gerstner
-Heerstr. 12
-70563 Stuttgart
+Zwernitzer Str. 12
+81243 München
 Deutschland
 
 E-Mail: info@krymo.software
@@ -11,7 +11,7 @@ Internet: https://krymo.software
 
 § 1. Geltungsbereich
 
-1.1. Die nachfolgenden Lizenzbestimmungen beziehen sich auf alle von Niklas Friedrich Gerstner (im weiteren Hersteller genannt) kostenlos zur Verfügung gestellten Versionen der Produkte auf der Website https://www.woltlab.com/, https://krymo.software/, https://www.spigotmc.org/ und https://www.mc-market.org/, hergestellt durch Niklas Friedrich Gerstner.
+1.1. Die nachfolgenden Lizenzbestimmungen beziehen sich auf alle kostenlos zur Verfügung gestellten Versionen der Produkte auf den Websites https://www.woltlab.com/ und https://krymo.software/, die durch Niklas Friedrich Gerstner (im weiteren Hersteller genannt) hergestellt worden sind.
 
 1.2. Es gelten ausschließlich die Bestimmungen dieser Lizenzvereinbarung. Mündlichen Nebenabreden oder etwaigen Geschäftsbedingungen der herunterladenden Person werden bereits jetzt widersprochen.
 
@@ -47,7 +47,7 @@ Internet: https://krymo.software
 
 6.1. Im Hinblick auf sämtliche Rechtsbeziehungen aus diesen Lizenzbestimmungen gilt das Recht der Bundesrepublik Deutschland unter Ausschluss des UN-Kaufrechts.
 
-6.2. Sofern Sie Kaufmann im Sinne des Handelsgesetzbuches, juristische Person des öffentlichen Rechts oder öffentlich rechtliches Sondervermögen sind, wird für sämtliche Streitigkeiten, die im Rahmen der Abwicklung dieser Lizenzvereinbarung entstehen, Stuttgart als Gerichtstand vereinbart.
+6.2. Sofern Sie Kaufmann im Sinne des Handelsgesetzbuches, juristische Person des öffentlichen Rechts oder öffentlich rechtliches Sondervermögen sind, wird für sämtliche Streitigkeiten, die im Rahmen der Abwicklung dieser Lizenzvereinbarung entstehen, München als Gerichtstand vereinbart.
 
 
 --------------------
@@ -56,8 +56,8 @@ Internet: https://krymo.software
 Manufacturer:
 
 Niklas Friedrich Gerstner
-Heerstr. 12
-70563 Stuttgart
+Zwernitzer Str. 12
+81243 München
 Germany
 
 Email: info@krymo.software
@@ -66,7 +66,7 @@ Internet: https://krymo.software
 
 § 1. Scope of application
 
-1.1 The following license terms refer to all versions of the products provided free of charge by Niklas Friedrich Gerstner (hereinafter referred to as manufacturer) on the website https://www.woltlab.com/, https://krymo.software/, https://www.spigotmc.org/ and https://www.mc-market.org/, manufactured by Niklas Friedrich Gerstner.
+1.1 The following license terms refer to all versions of the products provided free of charge on the websites https://www.woltlab.com/ and https://krymo.software/ that were manufactured by Niklas Friedrich Gerstner (hereinafter referred to as manufacturer).
 
 1.2 The provisions of this license agreement apply exclusively. Oral subsidiary agreements or any terms and conditions of the person downloading are already contradicted now.
 
@@ -102,4 +102,4 @@ Internet: https://krymo.software
 
 6.1 The law of the Federal Republic of Germany shall apply with regard to all legal relationships arising from these license provisions, excluding the UN Convention on Contracts for the International Sale of Goods.
 
-6.2 If you are a merchant within the meaning of the German Commercial Code, a legal entity under public law or a special fund under public law, Stuttgart is agreed to be the place of jurisdiction for all disputes arising in connection with the execution of this license agreement.
+6.2 If you are a merchant within the meaning of the German Commercial Code, a legal entity under public law or a special fund under public law, München in Germany is agreed to be the place of jurisdiction for all disputes arising in connection with the execution of this license agreement.

--- a/constants.php
+++ b/constants.php
@@ -3,8 +3,8 @@
  * Defines constants for autocompletion in IDEs. This file is not meant to be actively used anywhere!
  *
  * @author      Niklas Friedrich Gerstner
- * @copyright   2022 Krymo Software
- * @license     Krymo Software - Commercial Products License <https://krymo.software/license-terms/#commercial-products>
+ * @copyright   2024 Krymo Software
+ * @license     Krymo Software - Free Products License <https://krymo.software/license-terms/#free-products>
  */
 
 // option constants

--- a/eventListener.xml
+++ b/eventListener.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/eventListener.xsd">
-    <import>
-        <eventlistener name="userPageGroupList">
-            <eventclassname>wcf\page\UserPage</eventclassname>
-            <eventname>readData,assignVariables</eventname>
-            <listenerclassname>wcf\system\event\listener\UserPageGroupListListener</listenerclassname>
-            <inherit>1</inherit>
-            <environment>user</environment>
-        </eventlistener>
-    </import>
+<data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/6.0/eventListener.xsd">
+	<import>
+		<eventlistener name="userPageGroupList">
+			<eventclassname>wcf\page\UserPage</eventclassname>
+			<eventname>readData,assignVariables</eventname>
+			<listenerclassname>wcf\system\event\listener\UserPageGroupListListener</listenerclassname>
+			<inherit>1</inherit>
+			<environment>user</environment>
+		</eventlistener>
+	</import>
 </data>

--- a/files/lib/system/event/listener/UserPageGroupListListener.class.php
+++ b/files/lib/system/event/listener/UserPageGroupListListener.class.php
@@ -11,7 +11,7 @@ use wcf\util\ArrayUtil;
  * Provides the list of assigned user groups in user profiles.
  *
  * @author      Niklas Friedrich Gerstner
- * @copyright   2022 Krymo Software
+ * @copyright   2024 Krymo Software
  * @license     Krymo Software - Free Products License <https://krymo.software/license-terms/#free-products>
  * @package     WoltLabSuite\Core\System\Event\Listener
  */

--- a/files/lib/system/event/listener/UserPageGroupListListener.class.php
+++ b/files/lib/system/event/listener/UserPageGroupListListener.class.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace wcf\system\event\listener;
 
 use wcf\data\user\group\UserGroup;
@@ -14,10 +15,11 @@ use wcf\util\ArrayUtil;
  * @license     Krymo Software - Free Products License <https://krymo.software/license-terms/#free-products>
  * @package     WoltLabSuite\Core\System\Event\Listener
  */
-class UserPageGroupListListener implements IParameterizedEventListener {
+class UserPageGroupListListener implements IParameterizedEventListener
+{
     /**
      * instance of UserPage
-     * @var	UserPage
+     * @var UserPage
      */
     protected $eventObj;
 
@@ -36,62 +38,69 @@ class UserPageGroupListListener implements IParameterizedEventListener {
     /**
      * @inheritDoc
      */
-    public function execute($eventObj, $className, $eventName, array &$parameters) {
+    public function execute($eventObj, $className, $eventName, array &$parameters)
+    {
         $this->eventObj = $eventObj;
-        $this->$eventName();
+        $this->{$eventName}();
     }
 
     /**
      * Handles the assignVariables event.
      */
-    protected function assignVariables() {
+    protected function assignVariables()
+    {
         WCF::getTPL()->assign([
             'canViewUserPageGroupList' => $this->canViewUserPageGroupList,
-            'userGroups' => $this->userGroups
+            'userGroups' => $this->userGroups,
         ]);
     }
 
     /**
      * Handles the readData event.
      */
-    protected function readData() {
+    protected function readData()
+    {
         $user = $this->eventObj->user;
         $this->canViewUserPageGroupList = WCF::getSession()->getPermission('user.profile.canViewUserPageGroupList');
 
         if (!$this->canViewUserPageGroupList) {
             $isOwnProfile = $user->userID === WCF::getUser()->userID;
-            $this->canViewUserPageGroupList = $isOwnProfile && WCF::getSession()->getPermission('user.profile.canViewUserPageGroupListOwnProfile');
+            $this->canViewUserPageGroupList = $isOwnProfile && WCF::getSession()->getPermission(
+                'user.profile.canViewUserPageGroupListOwnProfile'
+            );
         }
 
         if ($this->canViewUserPageGroupList) {
-            $hiddenGroupIDs = ArrayUtil::toIntegerArray(ArrayUtil::trim(explode(',', PROFILE_GROUPLIST_HIDDEN_GROUPS)));
-            $shownGroupIDs = array_diff($user->getGroupIDs(), $hiddenGroupIDs);
+            $hiddenGroupIDs = ArrayUtil::toIntegerArray(
+                ArrayUtil::trim(\explode(',', PROFILE_GROUPLIST_HIDDEN_GROUPS))
+            );
+            $shownGroupIDs = \array_diff($user->getGroupIDs(), $hiddenGroupIDs);
             $userGroups = UserGroup::getGroupsByIDs($shownGroupIDs);
 
-            switch(PROFILE_GROUPLIST_SORT_BY) {
-                case 'priority_desc': {
+            switch (PROFILE_GROUPLIST_SORT_BY) {
+                case 'priority_desc':
                     \uasort($userGroups, static function (UserGroup $groupA, UserGroup $groupB) {
                         return static::compareGroupPriority($groupA, $groupB);
                     });
                     break;
-                }
-                case 'priority_asc': {
+
+                case 'priority_asc':
                     \uasort($userGroups, static function (UserGroup $groupA, UserGroup $groupB) {
                         return static::compareGroupPriority($groupA, $groupB, false);
                     });
                     break;
-                }
-                case 'alphabetical': {
+
+                case 'alphabetical':
                     UserGroup::sortGroups($userGroups);
                     break;
-                }
             }
 
             $this->userGroups = $userGroups;
         }
     }
 
-    private static function compareGroupPriority(UserGroup $groupA, UserGroup $groupB, bool $sortDescending = true): int {
+    private static function compareGroupPriority(UserGroup $groupA, UserGroup $groupB, bool $sortDescending = true): int
+    {
         if ($groupA->priority === $groupB->priority) {
             return 0;
         }

--- a/files/lib/system/event/listener/UserPageGroupListListener.class.php
+++ b/files/lib/system/event/listener/UserPageGroupListListener.class.php
@@ -15,7 +15,7 @@ use wcf\util\ArrayUtil;
  * @license     Krymo Software - Free Products License <https://krymo.software/license-terms/#free-products>
  * @package     WoltLabSuite\Core\System\Event\Listener
  */
-class UserPageGroupListListener implements IParameterizedEventListener
+final class UserPageGroupListListener implements IParameterizedEventListener
 {
     /**
      * instance of UserPage

--- a/files/lib/system/event/listener/UserPageGroupListListener.class.php
+++ b/files/lib/system/event/listener/UserPageGroupListListener.class.php
@@ -17,29 +17,26 @@ use wcf\util\ArrayUtil;
  */
 final class UserPageGroupListListener implements IParameterizedEventListener
 {
-    /**
-     * instance of UserPage
-     * @var UserPage
-     */
-    protected $eventObj;
+    protected UserPage $eventObj;
 
-    /**
-     * true if the user can view the group list
-     * @var boolean
-     */
-    protected $canViewUserPageGroupList = false;
+    protected bool $canViewUserPageGroupList = false;
 
     /**
      * list of user groups which are assigned to the user
+     *
      * @var UserGroup[]
      */
-    protected $userGroups = [];
+    protected array $userGroups = [];
 
     /**
      * @inheritDoc
      */
-    public function execute($eventObj, $className, $eventName, array &$parameters)
-    {
+    public function execute(
+        $eventObj,
+        $className,
+        $eventName,
+        array &$parameters
+    ): void {
         $this->eventObj = $eventObj;
         $this->{$eventName}();
     }
@@ -47,7 +44,7 @@ final class UserPageGroupListListener implements IParameterizedEventListener
     /**
      * Handles the assignVariables event.
      */
-    protected function assignVariables()
+    protected function assignVariables(): void
     {
         WCF::getTPL()->assign([
             'canViewUserPageGroupList' => $this->canViewUserPageGroupList,
@@ -58,16 +55,19 @@ final class UserPageGroupListListener implements IParameterizedEventListener
     /**
      * Handles the readData event.
      */
-    protected function readData()
+    protected function readData(): void
     {
         $user = $this->eventObj->user;
-        $this->canViewUserPageGroupList = WCF::getSession()->getPermission('user.profile.canViewUserPageGroupList');
+        $this->canViewUserPageGroupList = WCF::getSession()->getPermission(
+            'user.profile.canViewUserPageGroupList'
+        );
 
         if (!$this->canViewUserPageGroupList) {
             $isOwnProfile = $user->userID === WCF::getUser()->userID;
-            $this->canViewUserPageGroupList = $isOwnProfile && WCF::getSession()->getPermission(
-                'user.profile.canViewUserPageGroupListOwnProfile'
-            );
+            $this->canViewUserPageGroupList = $isOwnProfile
+                && WCF::getSession()->getPermission(
+                    'user.profile.canViewUserPageGroupListOwnProfile'
+                );
         }
 
         if ($this->canViewUserPageGroupList) {
@@ -79,15 +79,28 @@ final class UserPageGroupListListener implements IParameterizedEventListener
 
             switch (PROFILE_GROUPLIST_SORT_BY) {
                 case 'priority_desc':
-                    \uasort($userGroups, static function (UserGroup $groupA, UserGroup $groupB) {
-                        return static::compareGroupPriority($groupA, $groupB);
-                    });
+                    \uasort(
+                        $userGroups,
+                        function (UserGroup $groupA, UserGroup $groupB) {
+                            return $this->compareGroupPriority(
+                                $groupA,
+                                $groupB
+                            );
+                        }
+                    );
                     break;
 
                 case 'priority_asc':
-                    \uasort($userGroups, static function (UserGroup $groupA, UserGroup $groupB) {
-                        return static::compareGroupPriority($groupA, $groupB, false);
-                    });
+                    \uasort(
+                        $userGroups,
+                        function (UserGroup $groupA, UserGroup $groupB) {
+                            return $this->compareGroupPriority(
+                                $groupA,
+                                $groupB,
+                                false
+                            );
+                        }
+                    );
                     break;
 
                 case 'alphabetical':
@@ -99,8 +112,11 @@ final class UserPageGroupListListener implements IParameterizedEventListener
         }
     }
 
-    private static function compareGroupPriority(UserGroup $groupA, UserGroup $groupB, bool $sortDescending = true): int
-    {
+    private function compareGroupPriority(
+        UserGroup $groupA,
+        UserGroup $groupB,
+        bool $sortDescending = true
+    ): int {
         if ($groupA->priority === $groupB->priority) {
             return 0;
         }

--- a/language/de.xml
+++ b/language/de.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<language languagecode="de" xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/language.xsd">
-    <category name="wcf.acp.option">
-        <item name="wcf.acp.option.category.user.profile.grouplist"><![CDATA[Auflistung zugewiesener Benutzergruppen in Benutzerprofilen]]></item>
-        <item name="wcf.acp.option.profile_grouplist_hidden_groups"><![CDATA[Zu versteckende Benutzergruppen]]></item>
-        <item name="wcf.acp.option.profile_grouplist_sort_by"><![CDATA[Sortierung der Benutzergruppen]]></item>
-        <item name="wcf.acp.option.profile_grouplist_sort_by.priority_desc"><![CDATA[Nach Priorität (absteigend)]]></item>
-        <item name="wcf.acp.option.profile_grouplist_sort_by.priority_asc"><![CDATA[Nach Priorität (aufsteigend)]]></item>
-        <item name="wcf.acp.option.profile_grouplist_sort_by.alphabetical"><![CDATA[Alphabetisch]]></item>
-    </category>
-    <category name="wcf.acp.group">
-        <item name="wcf.acp.group.option.user.profile.canViewUserPageGroupList"><![CDATA[Kann Auflistung zugewiesener Benutzergruppen in Benutzerprofilen sehen]]></item>
-        <item name="wcf.acp.group.option.user.profile.canViewUserPageGroupListOwnProfile"><![CDATA[Kann Auflistung zugewiesener Benutzergruppen im eigenen Benutzerprofil sehen]]></item>
-    </category>
-    <category name="wcf.user.profile">
-        <item name="wcf.user.profile.grouplist"><![CDATA[Benutzergruppen]]></item>
-    </category>
+<language languagecode="de" xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/6.0/language.xsd">
+	<import>
+		<category name="wcf.acp.option">
+			<item name="wcf.acp.option.category.user.profile.grouplist"><![CDATA[Auflistung zugewiesener Benutzergruppen in Benutzerprofilen]]></item>
+			<item name="wcf.acp.option.profile_grouplist_hidden_groups"><![CDATA[Zu versteckende Benutzergruppen]]></item>
+			<item name="wcf.acp.option.profile_grouplist_sort_by"><![CDATA[Sortierung der Benutzergruppen]]></item>
+			<item name="wcf.acp.option.profile_grouplist_sort_by.priority_desc"><![CDATA[Nach Priorität (absteigend)]]></item>
+			<item name="wcf.acp.option.profile_grouplist_sort_by.priority_asc"><![CDATA[Nach Priorität (aufsteigend)]]></item>
+			<item name="wcf.acp.option.profile_grouplist_sort_by.alphabetical"><![CDATA[Alphabetisch]]></item>
+		</category>
+		<category name="wcf.acp.group">
+			<item name="wcf.acp.group.option.user.profile.canViewUserPageGroupList"><![CDATA[Kann Auflistung zugewiesener Benutzergruppen in Benutzerprofilen sehen]]></item>
+			<item name="wcf.acp.group.option.user.profile.canViewUserPageGroupListOwnProfile"><![CDATA[Kann Auflistung zugewiesener Benutzergruppen im eigenen Benutzerprofil sehen]]></item>
+		</category>
+		<category name="wcf.user.profile">
+			<item name="wcf.user.profile.grouplist"><![CDATA[Benutzergruppen]]></item>
+		</category>
+	</import>
 </language>

--- a/language/en.xml
+++ b/language/en.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<language languagecode="en" xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/language.xsd">
-    <category name="wcf.acp.option">
-        <item name="wcf.acp.option.category.user.profile.grouplist"><![CDATA[List of Assigned User Groups in User Profiles]]></item>
-        <item name="wcf.acp.option.profile_grouplist_hidden_groups"><![CDATA[User groups to hide]]></item>
-        <item name="wcf.acp.option.profile_grouplist_sort_by"><![CDATA[Sorting of user groups]]></item>
-        <item name="wcf.acp.option.profile_grouplist_sort_by.priority_desc"><![CDATA[By priority (descending)]]></item>
-        <item name="wcf.acp.option.profile_grouplist_sort_by.priority_asc"><![CDATA[By priority (ascending)]]></item>
-        <item name="wcf.acp.option.profile_grouplist_sort_by.alphabetical"><![CDATA[Alphabetical]]></item>
-    </category>
-    <category name="wcf.acp.group">
-        <item name="wcf.acp.group.option.user.profile.canViewUserPageGroupList"><![CDATA[Can view list of assigned user groups in user profiles]]></item>
-        <item name="wcf.acp.group.option.user.profile.canViewUserPageGroupListOwnProfile"><![CDATA[Can view list of assigned user groups in own user profile]]></item>
-    </category>
-    <category name="wcf.user.profile">
-        <item name="wcf.user.profile.grouplist"><![CDATA[User Groups]]></item>
-    </category>
+<language languagecode="en" xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/6.0/language.xsd">
+	<import>
+		<category name="wcf.acp.option">
+			<item name="wcf.acp.option.category.user.profile.grouplist"><![CDATA[List of Assigned User Groups in User Profiles]]></item>
+			<item name="wcf.acp.option.profile_grouplist_hidden_groups"><![CDATA[User groups to hide]]></item>
+			<item name="wcf.acp.option.profile_grouplist_sort_by"><![CDATA[Sorting of user groups]]></item>
+			<item name="wcf.acp.option.profile_grouplist_sort_by.priority_desc"><![CDATA[By priority (descending)]]></item>
+			<item name="wcf.acp.option.profile_grouplist_sort_by.priority_asc"><![CDATA[By priority (ascending)]]></item>
+			<item name="wcf.acp.option.profile_grouplist_sort_by.alphabetical"><![CDATA[Alphabetical]]></item>
+		</category>
+		<category name="wcf.acp.group">
+			<item name="wcf.acp.group.option.user.profile.canViewUserPageGroupList"><![CDATA[Can view list of assigned user groups in user profiles]]></item>
+			<item name="wcf.acp.group.option.user.profile.canViewUserPageGroupListOwnProfile"><![CDATA[Can view list of assigned user groups in own user profile]]></item>
+		</category>
+		<category name="wcf.user.profile">
+			<item name="wcf.user.profile.grouplist"><![CDATA[User Groups]]></item>
+		</category>
+	</import>
 </language>

--- a/option.xml
+++ b/option.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/option.xsd">
-    <import>
-        <categories>
-            <category name="user.profile.grouplist">
-                <parent>user.profile</parent>
-            </category>
-        </categories>
-        <options>
-            <option name="profile_grouplist_hidden_groups">
-                <categoryname>user.profile.grouplist</categoryname>
-                <optiontype>userGroup</optiontype>
-            </option>
-            <option name="profile_grouplist_sort_by">
-                <categoryname>user.profile.grouplist</categoryname>
-                <optiontype>select</optiontype>
-                <defaultvalue>priority_desc</defaultvalue>
-                <selectoptions>priority_desc:wcf.acp.option.profile_grouplist_sort_by.priority_desc
+<data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/6.0/option.xsd">
+	<import>
+		<categories>
+			<category name="user.profile.grouplist">
+				<parent>user.profile</parent>
+			</category>
+		</categories>
+		<options>
+			<option name="profile_grouplist_hidden_groups">
+				<categoryname>user.profile.grouplist</categoryname>
+				<optiontype>userGroup</optiontype>
+			</option>
+			<option name="profile_grouplist_sort_by">
+				<categoryname>user.profile.grouplist</categoryname>
+				<optiontype>select</optiontype>
+				<defaultvalue>priority_desc</defaultvalue>
+				<selectoptions>priority_desc:wcf.acp.option.profile_grouplist_sort_by.priority_desc
 priority_asc:wcf.acp.option.profile_grouplist_sort_by.priority_asc
 alphabetical:wcf.acp.option.profile_grouplist_sort_by.alphabetical</selectoptions>
-            </option>
-        </options>
-    </import>
+			</option>
+		</options>
+	</import>
 </data>

--- a/package.xml
+++ b/package.xml
@@ -5,8 +5,8 @@
 		<packagename language="de"><![CDATA[Auflistung zugewiesener Benutzergruppen in Benutzerprofilen]]></packagename>
 		<packagedescription><![CDATA[This package provides a list of assigned user groups in user profiles for the WoltLab Suite™ Core.]]></packagedescription>
 		<packagedescription language="de"><![CDATA[Dieses Paket stellt eine Auflistung zugewiesener Benutzergruppen in Benutzerprofilen den WoltLab Suite™ Core zur Verfügung.]]></packagedescription>
-		<version>1.1.0</version>
-		<date>2022-12-03</date>
+		<version>1.2.0</version>
+		<date>2023-10-24</date>
 		<packageurl><![CDATA[https://krymo.software]]></packageurl>
 	</packageinformation>
 
@@ -16,11 +16,11 @@
 	</authorinformation>
 
 	<requiredpackages>
-		<requiredpackage minversion="5.3.0">com.woltlab.wcf</requiredpackage>
+		<requiredpackage minversion="5.5.18">com.woltlab.wcf</requiredpackage>
 	</requiredpackages>
 
 	<excludedpackages>
-		<excludedpackage version="6.0.0 Alpha 1">com.woltlab.wcf</excludedpackage>
+		<excludedpackage version="7.0.0 Alpha 1">com.woltlab.wcf</excludedpackage>
 	</excludedpackages>
 
 	<instructions type="install">
@@ -33,9 +33,8 @@
 		<instruction type="templateListener"/>
 	</instructions>
 
-	<instructions type="update" fromversion="1.0.3*">
+	<instructions type="update" fromversion="1.1.*">
 		<instruction type="file"/>
-		<instruction type="language"/>
-		<instruction type="option"/>
+		<instruction type="template"/>
 	</instructions>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
 		<packagedescription><![CDATA[This package provides a list of assigned user groups in user profiles for the WoltLab Suite™ Core.]]></packagedescription>
 		<packagedescription language="de"><![CDATA[Dieses Paket stellt eine Auflistung zugewiesener Benutzergruppen in Benutzerprofilen den WoltLab Suite™ Core zur Verfügung.]]></packagedescription>
 		<version>1.2.0</version>
-		<date>2023-10-24</date>
+		<date>2024-01-01</date>
 		<packageurl><![CDATA[https://krymo.software]]></packageurl>
 	</packageinformation>
 
@@ -16,11 +16,11 @@
 	</authorinformation>
 
 	<requiredpackages>
-		<requiredpackage minversion="5.5.18">com.woltlab.wcf</requiredpackage>
+		<requiredpackage minversion="6.0.6">com.woltlab.wcf</requiredpackage>
 	</requiredpackages>
 
 	<excludedpackages>
-		<excludedpackage version="7.0.0 Alpha 1">com.woltlab.wcf</excludedpackage>
+		<excludedpackage version="6.1.0 Alpha 1">com.woltlab.wcf</excludedpackage>
 	</excludedpackages>
 
 	<instructions type="install">

--- a/package.xml
+++ b/package.xml
@@ -1,41 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package name="software.krymo.woltlab.suite.core.user.profile.grouplist" xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/package.xsd">
-    <packageinformation>
-        <packagename><![CDATA[List of Assigned User Groups in User Profiles]]></packagename>
-        <packagename language="de"><![CDATA[Auflistung zugewiesener Benutzergruppen in Benutzerprofilen]]></packagename>
-        <packagedescription><![CDATA[This package provides a list of assigned user groups in user profiles for the WoltLab Suite™ Core.]]></packagedescription>
-        <packagedescription language="de"><![CDATA[Dieses Paket stellt eine Auflistung zugewiesener Benutzergruppen in Benutzerprofilen den WoltLab Suite™ Core zur Verfügung.]]></packagedescription>
-        <version>1.1.0</version>
-        <date>2022-12-03</date>
-        <packageurl><![CDATA[https://krymo.software]]></packageurl>
-    </packageinformation>
+<package name="software.krymo.woltlab.suite.core.user.profile.grouplist" xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/6.0/package.xsd">
+	<packageinformation>
+		<packagename><![CDATA[List of Assigned User Groups in User Profiles]]></packagename>
+		<packagename language="de"><![CDATA[Auflistung zugewiesener Benutzergruppen in Benutzerprofilen]]></packagename>
+		<packagedescription><![CDATA[This package provides a list of assigned user groups in user profiles for the WoltLab Suite™ Core.]]></packagedescription>
+		<packagedescription language="de"><![CDATA[Dieses Paket stellt eine Auflistung zugewiesener Benutzergruppen in Benutzerprofilen den WoltLab Suite™ Core zur Verfügung.]]></packagedescription>
+		<version>1.1.0</version>
+		<date>2022-12-03</date>
+		<packageurl><![CDATA[https://krymo.software]]></packageurl>
+	</packageinformation>
 
-    <authorinformation>
-        <author><![CDATA[Krymo Software]]></author>
-        <authorurl><![CDATA[https://krymo.software]]></authorurl>
-    </authorinformation>
+	<authorinformation>
+		<author><![CDATA[Krymo Software]]></author>
+		<authorurl><![CDATA[https://krymo.software]]></authorurl>
+	</authorinformation>
 
-    <requiredpackages>
-        <requiredpackage minversion="5.3.0">com.woltlab.wcf</requiredpackage>
-    </requiredpackages>
+	<requiredpackages>
+		<requiredpackage minversion="5.3.0">com.woltlab.wcf</requiredpackage>
+	</requiredpackages>
 
-    <excludedpackages>
-        <excludedpackage version="6.0.0 Alpha 1">com.woltlab.wcf</excludedpackage>
-    </excludedpackages>
+	<excludedpackages>
+		<excludedpackage version="6.0.0 Alpha 1">com.woltlab.wcf</excludedpackage>
+	</excludedpackages>
 
-    <instructions type="install">
-        <instruction type="file"/>
-        <instruction type="template"/>
-        <instruction type="language"/>
-        <instruction type="option"/>
-        <instruction type="userGroupOption"/>
-        <instruction type="eventListener"/>
-        <instruction type="templateListener"/>
-    </instructions>
+	<instructions type="install">
+		<instruction type="file"/>
+		<instruction type="template"/>
+		<instruction type="language"/>
+		<instruction type="option"/>
+		<instruction type="userGroupOption"/>
+		<instruction type="eventListener"/>
+		<instruction type="templateListener"/>
+	</instructions>
 
-    <instructions type="update" fromversion="1.0.3*">
-        <instruction type="file"/>
-        <instruction type="language"/>
-        <instruction type="option"/>
-    </instructions>
+	<instructions type="update" fromversion="1.0.3*">
+		<instruction type="file"/>
+		<instruction type="language"/>
+		<instruction type="option"/>
+	</instructions>
 </package>

--- a/templateListener.xml
+++ b/templateListener.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/templateListener.xsd">
-    <import>
-        <templatelistener name="userPageGroupList">
-            <environment>user</environment>
-            <templatename>userSidebar</templatename>
-            <eventname>boxes</eventname>
-            <templatecode><![CDATA[{include file='__userSidebarGroupListBox'}]]></templatecode>
-        </templatelistener>
-    </import>
+<data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/6.0/templateListener.xsd">
+	<import>
+		<templatelistener name="userPageGroupList">
+			<environment>user</environment>
+			<templatename>userSidebar</templatename>
+			<eventname>boxes</eventname>
+			<templatecode><![CDATA[{include file='__userSidebarGroupListBox'}]]></templatecode>
+		</templatelistener>
+	</import>
 </data>

--- a/templates/__userSidebarGroupListBox.tpl
+++ b/templates/__userSidebarGroupListBox.tpl
@@ -1,13 +1,13 @@
 {if $canViewUserPageGroupList && $userGroups|count}
-    <section class="box" data-static-box-identifier="software.krymo.woltlab.suite.core.user.profile.grouplist.UserGroupList">
-        <h2 class="boxTitle">{lang}wcf.user.profile.grouplist{/lang} <span class="badge">{#$userGroups|count}</span></h2>
+	<section class="box" data-static-box-identifier="software.krymo.woltlab.suite.core.user.profile.grouplist.UserGroupList">
+		<h2 class="boxTitle">{lang}wcf.user.profile.grouplist{/lang} <span class="badge">{#$userGroups|count}</span></h2>
 
-        <div class="boxContent">
-            <ul class="userGroupList">
-                {foreach from=$userGroups item=userGroup}
-                    <li>{$userGroup->getName()}</li>
-                {/foreach}
-            </ul>
-        </div>
-    </section>
+		<div class="boxContent">
+			<ul class="userGroupList">
+				{foreach from=$userGroups item=userGroup}
+					<li>{$userGroup->getName()}</li>
+				{/foreach}
+			</ul>
+		</div>
+	</section>
 {/if}

--- a/userGroupOption.xml
+++ b/userGroupOption.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/userGroupOption.xsd">
-    <import>
-        <options>
-            <option name="user.profile.canViewUserPageGroupList">
-                <categoryname>user.profile</categoryname>
-                <optiontype>boolean</optiontype>
-                <defaultvalue>0</defaultvalue>
-                <admindefaultvalue>1</admindefaultvalue>
-            </option>
-            <option name="user.profile.canViewUserPageGroupListOwnProfile">
-                <categoryname>user.profile</categoryname>
-                <optiontype>boolean</optiontype>
-                <defaultvalue>0</defaultvalue>
-                <admindefaultvalue>1</admindefaultvalue>
-                <usersonly>1</usersonly>
-            </option>
-        </options>
-    </import>
+<data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/6.0/userGroupOption.xsd">
+	<import>
+		<options>
+			<option name="user.profile.canViewUserPageGroupList">
+				<categoryname>user.profile</categoryname>
+				<optiontype>boolean</optiontype>
+				<defaultvalue>0</defaultvalue>
+				<admindefaultvalue>1</admindefaultvalue>
+			</option>
+			<option name="user.profile.canViewUserPageGroupListOwnProfile">
+				<categoryname>user.profile</categoryname>
+				<optiontype>boolean</optiontype>
+				<defaultvalue>0</defaultvalue>
+				<admindefaultvalue>1</admindefaultvalue>
+				<usersonly>1</usersonly>
+			</option>
+		</options>
+	</import>
 </data>


### PR DESCRIPTION
Ich habe ein paar Anpassungen für WSC 6.0 vorgenommen:

- Umstellung des Codestyles auf PSR-12, welcher schon länger von WoltLab genutzt wird
- ich habe die Klasse `UserPageGroupListListener` `final` gemacht, da sie nicht geerbt werden darf
- ich habe die Einrückung die XML-Dateien und Templates angepasst, da es Tabs und keine Spaces sein sollten
- ich habe dir bereits die package.xml fürs Update angepasst ;)